### PR TITLE
added atol and rtol option

### DIFF
--- a/bosonstar/ComplexBosonStar.py
+++ b/bosonstar/ComplexBosonStar.py
@@ -39,12 +39,15 @@ class Complex_Boson_Star:
 
     _finished_shooting = False
 
-    def __init__(self, e_pow_minus_delta_guess, phi0, Dim, Lambda, verbose=0):
+    def __init__(self, e_pow_minus_delta_guess, phi0, Dim, Lambda, verbose=0,
+            rtol = 1e-10, atol = 1e-10):
 
         self.e_pow_minus_delta_guess = e_pow_minus_delta_guess
         self._phi0 = phi0
         self._Dim = Dim
         self._Lambda = Lambda
+        self._atol = atol
+        self._rtol = rtol
 
         # Will give more messages with increasing value
         self.verbose = verbose
@@ -112,7 +115,7 @@ class Complex_Boson_Star:
         # Define initial data vector
         y0 = [e_pow_minus_delta_at_zero, 0, self._phi0, 0]
         # Solve differential equaion
-        sol = spi.odeint(self.eqns, y0, r)  # , h0 = 1e-10, hmax = 1e-3)
+        sol = spi.odeint(self.eqns, y0, r, atol = self._atol, rtol = self._rtol)
         phi_end = sol[-1, 2]
 
         if not output:

--- a/bosonstar/ComplexProcaSelfInteracting.py
+++ b/bosonstar/ComplexProcaSelfInteracting.py
@@ -20,6 +20,12 @@ class Complex_Proca_Star:
     _cA4 = None
     _GNewton = None
 
+    # ------------------------------------------------------------
+    # Scipy parameters
+    # ------------------------------------------------------------
+    _rtol = None
+    _atol = None
+
     verbose = None
     path = None
 
@@ -30,7 +36,8 @@ class Complex_Proca_Star:
 
     _finished_shooting = False
 
-    def __init__(self, sigma_guess, f0, cA4=0.0, mu=1, GNewton=1, verbose=0):
+    def __init__(self, sigma_guess, f0, cA4=0.0, mu=1, GNewton=1, verbose=0,
+            rtol = 1e-10, atol = 1e-10):
 
         self.sigma_guess = sigma_guess
         self._f0 = f0
@@ -39,6 +46,8 @@ class Complex_Proca_Star:
         self._mu = mu
         self._cA4 = cA4
         self._GNewton = GNewton
+        self._atol = atol
+        self._rtol = rtol
 
         # Will give more messages with increasing value
         self.verbose = verbose
@@ -110,7 +119,7 @@ class Complex_Proca_Star:
         # Define initial data vector
         y0 = [sigma_at_zero, 0, self._f0, 0, 0]
         # Solve differential equaion
-        sol = spi.odeint(self.eqns, y0, r)
+        sol = spi.odeint(self.eqns, y0, r, atol = self._atol, rtol = self._rtol)
         f_end = sol[-1, 2]
 
         if not output:

--- a/example/complex_vector_star_selfinteracting_solver.py
+++ b/example/complex_vector_star_selfinteracting_solver.py
@@ -12,12 +12,15 @@ mu = 1              # mass of the field
 cA4 = 0.0           # selfinteraction of field
 # Solver definitions
 Rstart = 10.4
-Rend = 40.00
+Rend = 50.00
 deltaR = 2
 N = 100000
 # for G = 4 use sigma_guess = 0.779
 GNewton = 1.0
 sigma_guess = 0.8734
+
+rtol = 1e-12
+atol = 1e-14
 
 verbose = 3
 eps = 1e-10  # Small epsilon to avoid r =  0
@@ -26,7 +29,8 @@ eps = 1e-10  # Small epsilon to avoid r =  0
 #   Main routine
 # ====================================
 
-pewpew = Complex_Proca_Star(sigma_guess, f0, cA4, mu, GNewton, verbose)
+pewpew = Complex_Proca_Star(sigma_guess, f0, cA4, mu, GNewton, verbose, rtol,
+        atol )
 pewpew.print_parameters()
 
 pewpew.radial_walker(Rstart, Rend, deltaR, N, eps)


### PR DESCRIPTION
Found that small cutoff of single Proca star has an effect on the evolution (rtol and atol default ~ 1e-8) and Rmax ~ 40
gives: 

https://user-images.githubusercontent.com/16085496/121918124-bfb77780-cd03-11eb-8f0b-656502241813.mp4

the Energy-density evolution is not constant, as we would expect for good initial data. When increasing the (rtol and atol) to larger values of 10^(-12) and 10^(-14) respectively and Rmax ~ 50 seems to solve the problem : 

https://user-images.githubusercontent.com/16085496/121918658-453b2780-cd04-11eb-86d2-6dc6ef9d22ad.mp4

which gives very constant evolution.

I added the choice of adding rtol and atol as a parameter now and choose more agressive default values (10^(-10) for atol and rtol) than scipy uses.



 